### PR TITLE
feat(home/amunoz): add atuin and gemini-cli, simplify oppy modules

### DIFF
--- a/homes/amunoz/home.nix
+++ b/homes/amunoz/home.nix
@@ -5,6 +5,7 @@
     homeDirectory = "/home/amunoz";
 
     packages = with pkgs; [
+      atuin # shared command history
       autoconf
       automake
       autotools-language-server # make
@@ -58,6 +59,7 @@
       nix-search-cli # find nix packages
       nixfmt-rfc-style # Nix formatting (for nixpkgs)
       nixfmt-tree # Format entire directories of nix
+      nom # more informative nix develop
       nodePackages.bash-language-server # bash
       pandoc # Convert between formats
       parallel # GNU parallel

--- a/homes/amunoz/home.nix
+++ b/homes/amunoz/home.nix
@@ -5,7 +5,6 @@
     homeDirectory = "/home/amunoz";
 
     packages = with pkgs; [
-      atuin # shared command history
       autoconf
       automake
       autotools-language-server # make

--- a/homes/amunoz/home.nix
+++ b/homes/amunoz/home.nix
@@ -59,7 +59,6 @@
       nix-search-cli # find nix packages
       nixfmt-rfc-style # Nix formatting (for nixpkgs)
       nixfmt-tree # Format entire directories of nix
-      nom # more informative nix develop
       nodePackages.bash-language-server # bash
       pandoc # Convert between formats
       parallel # GNU parallel

--- a/homes/amunoz/home.nix
+++ b/homes/amunoz/home.nix
@@ -119,4 +119,27 @@
       set --universal pure_enable_nixdevshell true
     '';
   };
+  programs.atuin =
+    let
+      atuin_daemon_p = if pkgs.stdenv.isLinux then true else false;
+    in
+    {
+      enable = true;
+      # package = pkgs.stable.atuin;
+      enableFishIntegration = true;
+      enableBashIntegration = true;
+      enableNushellIntegration = true;
+      settings = {
+        auto_sync = true;
+        sync_frequency = "5m";
+        sync_address = "https://api.atuin.sh";
+        search_mode = "prefix";
+        daemon = {
+          enabled = atuin_daemon_p;
+          socket_path = "/home/amunoz/.local/share/atuin/atuin.sock";
+        };
+        # // atuin_key_path;
+      };
+    };
+
 }

--- a/homes/amunoz/home.nix
+++ b/homes/amunoz/home.nix
@@ -27,6 +27,7 @@
       fontconfig # Needed for napari
       fzf # fuzzy finder
       gawk # Main awk
+      gemini-cli
       git
       gnumake # Necessary for emacs' vterm
       gnumeric

--- a/homes/amunoz/machines/oppy.nix
+++ b/homes/amunoz/machines/oppy.nix
@@ -8,14 +8,14 @@
   imports = [
     ../home.nix
     ../../common/home_manager.nix
-    ../../common/dev
-    ../../common/dev/kalam.nix
-    ../../common/themes
-    (import ../../common/dev/editors.nix {
-      inherit pkgs config inputs;
-      enableNvim = false;
-      enableAstro = false;
-    })
+    # ../../common/dev
+    # ../../common/dev/kalam.nix
+    # ../../common/themes
+    # (import ../../common/dev/editors.nix {
+    #   inherit pkgs config inputs;
+    #   enableNvim = false;
+    #   enableAstro = false;
+    # })
     (import ../../common/dev/git.nix {
       username = "Alán F. Muñoz";
       userEmail = "amunozgo@broadinstitute.org";


### PR DESCRIPTION
- Add gemini-cli to packages
- Configure atuin for shell history sync (auto-sync every 5m, daemon on Linux, fish/bash/nushell integration)
- Disable common/dev, kalam, themes, and editors imports on oppy in favor of a leaner per-user setup