### PR TITLE
chore: promote jfredinh, fix zsh import, overlay claude-code

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -199,6 +199,27 @@
         "type": "github"
       }
     },
+    "claude-code-nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777126457,
+        "narHash": "sha256-jE5KMGZc9p2H86gCi38o2H3loV/OwICJVa8YbDmpDyg=",
+        "owner": "sadjow",
+        "repo": "claude-code-nix",
+        "rev": "002de6e1b2d10f4646c68af360d9dc92b89a6be9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sadjow",
+        "repo": "claude-code-nix",
+        "type": "github"
+      }
+    },
     "comin": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -449,7 +470,7 @@
     },
     "flake-utils": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -467,7 +488,25 @@
     },
     "flake-utils_2": {
       "inputs": {
-        "systems": "systems_6"
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_7"
       },
       "locked": {
         "lastModified": 1681202837,
@@ -705,7 +744,7 @@
         "nixpkgs": [
           "nixpkgs-unstable"
         ],
-        "systems": "systems_2",
+        "systems": "systems_3",
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
@@ -936,7 +975,7 @@
           "nixpkgs"
         ],
         "nuschtosSearch": "nuschtosSearch",
-        "systems": "systems_4"
+        "systems": "systems_5"
       },
       "locked": {
         "lastModified": 1769049374,
@@ -980,7 +1019,7 @@
     },
     "nuschtosSearch": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "ixx": "ixx",
         "nixpkgs": [
           "nixvim",
@@ -1006,6 +1045,7 @@
         "agenix": "agenix",
         "astroank": "astroank",
         "autoraise-tap": "autoraise-tap",
+        "claude-code-nix": "claude-code-nix",
         "comin": "comin",
         "darwin": "darwin_2",
         "deskflow-tap": "deskflow-tap",
@@ -1046,7 +1086,7 @@
           "nixpkgs"
         ],
         "nur": "nur",
-        "systems": "systems_5",
+        "systems": "systems_6",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
@@ -1144,6 +1184,21 @@
       }
     },
     "systems_6": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_7": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -1296,7 +1351,7 @@
     },
     "vscode-server": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -117,6 +117,11 @@
     jail-nix.url = "sourcehut:~alexdavid/jail.nix";
     llm-agents.url = "github:numtide/llm-agents.nix";
     llm-agents.inputs.nixpkgs.follows = "nixpkgs-unstable";
+
+    claude-code-nix = {
+      url = "github:sadjow/claude-code-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/homes/amunoz/home.nix
+++ b/homes/amunoz/home.nix
@@ -4,6 +4,8 @@
     ./configs/opencode.nix
   ];
 
+  nixpkgs.config.allowUnfree = true;
+
   home = {
     username = "amunoz";
     homeDirectory = "/home/amunoz";

--- a/homes/ank/machines/karkinos.nix
+++ b/homes/ank/machines/karkinos.nix
@@ -12,7 +12,7 @@
     ../../common/dev/kalam.nix
     ../../common/themes
     ../configs/opencode.nix
-    ../configs/zsh_alias.nix
+    ../configs/zsh.nix
     (import ../../common/dev/editors.nix {
       inherit pkgs config inputs;
       enableNvim = false;

--- a/homes/ank/machines/oppy.nix
+++ b/homes/ank/machines/oppy.nix
@@ -11,7 +11,7 @@
     ../../common/dev
     ../../common/dev/kalam.nix
     ../../common/themes
-    ../configs/zsh_alias.nix
+    ../configs/zsh.nix
     (import ../../common/dev/editors.nix {
       inherit pkgs config inputs;
       enableNvim = false;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -32,6 +32,11 @@
       unstable = upkgs;
     };
 
+  # Override claude-code with the version from sadjow/claude-code-nix
+  claude-code = final: _: {
+    claude-code = inputs.claude-code-nix.packages.${final.stdenv.hostPlatform.system}.claude-code;
+  };
+
   # Adds pkgs.git-worktree-custom == A custom version of this package
   git-worktree = final: _: {
     git-worktree-custom = final.vimUtils.buildVimPlugin {

--- a/users/cslab.nix
+++ b/users/cslab.nix
@@ -45,6 +45,19 @@
         ];
       };
     }
+    {
+      username = "jfredinh";
+      fullName = "Johan";
+      shell = "zsh";
+      sshKeys = [
+        ../homes/jfredinh/id_ed25519.pub
+      ];
+      homeModules = {
+        oppy = [
+          ../homes/jfredinh/machines/oppy.nix
+        ];
+      };
+    }
   ];
 
   regulars = [
@@ -84,19 +97,6 @@
       homeModules = {
         oppy = [
           ../homes/rshen/machines/oppy.nix
-        ];
-      };
-    }
-    {
-      username = "jfredinh";
-      fullName = "Johan";
-      shell = "zsh";
-      sshKeys = [
-        ../homes/jfredinh/id_ed25519.pub
-      ];
-      homeModules = {
-        oppy = [
-          ../homes/jfredinh/machines/oppy.nix
         ];
       };
     }


### PR DESCRIPTION
## Summary
- **users/cslab.nix**: Move `jfredinh` from `regulars` to `admins`, granting wheel/sudo (plus networkmanager) on oppy. Already an admin on karkinos via `users/cslab_karkinos.nix`.
- **homes/ank/machines/{oppy,karkinos}.nix**: Fix dangling import of `zsh_alias.nix` after it was renamed to `zsh.nix` in cleanup commit aa9e5a7. Without this, `nixos-rebuild` on oppy/karkinos fails with a missing-path error.
- **flake.nix / overlays/default.nix / flake.lock**: Add `sadjow/claude-code-nix` as a flake input (following nixpkgs) and overlay `pkgs.claude-code` with its package — tracks releases more closely (2.1.119 vs nixpkgs 2.1.81).
- **homes/amunoz/home.nix**: Enable `nixpkgs.config.allowUnfree` so the home-manager nixpkgs can evaluate `claude-code` (mkNeusisOS does not set `useGlobalPkgs`, so system-level allowUnfree does not propagate to home-manager).

## Test plan
- [x] `sudo nixos-rebuild build --flake .#oppy` succeeds (`/nix/store/fni1sb5r6g8vskcjn89ch6glywvyw4k1-nixos-system-oppy-25.11.20260404.36a6011`)
- [x] `nixos-rebuild switch --flake .#oppy` succeeds on oppy
- [x] `groups jfredinh` on oppy includes `wheel`
- [x] `claude --version` reflects 2.1.119